### PR TITLE
Allow as json serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /.bundle/
 /.yardoc
+/.ruby-version
+/.ruby-gemset
 /Gemfile.lock
 /_yardoc/
 /coverage/

--- a/README.md
+++ b/README.md
@@ -107,7 +107,11 @@ And then execute:
 
 ### Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment. To get started, you'll probably want to run something like:
+
+```
+TypeformData::Client.new(api_key: your_api_key).all_typeforms
+```
 
 ### Releasing a new version
 

--- a/lib/typeform_data/client.rb
+++ b/lib/typeform_data/client.rb
@@ -38,6 +38,10 @@ module TypeformData
       TypeformData::Typeform.new(@config, id: id)
     end
 
+    # The goals of this alias are:
+    #   1. To bring the serialization process within TypeformData's API, so
+    #        we can modify it in the future if needed.
+    #   2. Maintain symmetry with #load, which needs to be part of the API.
     def dump(object)
       Marshal.dump(object)
     end
@@ -57,6 +61,14 @@ module TypeformData
           marshaled.reconfig(@config)
         end
       }
+    end
+
+    def marshal_dump
+      raise 'Do not serialize TypeformData::Client-- it contains your API key'
+    end
+
+    def as_json(*_args)
+      raise 'Do not serialize TypeformData::Client-- it contains your API key'
     end
 
   end

--- a/lib/typeform_data/value_class.rb
+++ b/lib/typeform_data/value_class.rb
@@ -23,12 +23,47 @@ module TypeformData
       end
     end
 
+    # ActiveSupport defines Object#as_json in
+    # activesupport/lib/active_support/core_ext/object/json.rb which exists to separate
+    # stringification from serialization logic. as_json is not core Ruby, but we implement it here
+    # for compatibility with to_json when ActiveSupport is loaded.
+    #
     # In addition to protection against serializing the API key, this method is needed for #to_json
     # to work at all, since the :config object contains IO objects and ActiveSupport's #as_json
     # method fails when trying to serialize IO objects. See
     # https://github.com/rails/rails/issues/26132.
+    #
+    # Testing this method:
+    #
+    #   For now, we're not including ActiveSupport as a development dependency because of the risk
+    # of accidentally writing code that relies on an ActiveSupport core extension that might not
+    # be present where this gem is being used.
+    #
+    # To test this method in the console, add
+    #
+    #   spec.add_development_dependency 'activesupport'
+    #
+    # to typeform_data.gemspec and then run something like
+    #
+    #  require 'active_support'; require 'active_support/json'; \
+    #   c = TypeformData::Client.new(api_key: ...); \
+    #   at = c.all_typeforms; tf = at.reverse.find { |t| t.stats.completed > 0 }; \
+    #   tf.responses(completed: true, limit: 1).first.to_json
+    #
+    # using bin/console.
+    #
+    # One last thing: if you pass options #to_json or #as_json, Rails will use the same options for
+    # all calls in the object graph, so the following behavior is expected (if counterintuitive):
+    #
+    #    #   response.as_json(only: 'answers')
+    #   => {"answers"=>[{}, {}, {}, {}]}
+    #
+    # @param [Hash]
     def as_json(options = {})
-      super({ except: 'config' }.merge(options))
+      # Note: :config doesn't work here-- using the string form is mandatory.
+      return super({ except: 'config' }) if options.empty?
+
+      super(options.merge(except: ['config'] + Array(options[:except])))
     end
 
     def self.included(base)

--- a/lib/typeform_data/value_class.rb
+++ b/lib/typeform_data/value_class.rb
@@ -23,6 +23,14 @@ module TypeformData
       end
     end
 
+    # In addition to protection against serializing the API key, this method is needed for #to_json
+    # to work at all, since the :config object contains IO objects and ActiveSupport's #as_json
+    # method fails when trying to serialize IO objects. See
+    # https://github.com/rails/rails/issues/26132.
+    def as_json(options = {})
+      super({ except: 'config' }.merge(options))
+    end
+
     def self.included(base)
       base.extend(ClassMethods)
     end


### PR DESCRIPTION
After this PR, `response.to_json` should yield a good representation of the parsed data as JSON.

Not a priority to review (not blocking anything).